### PR TITLE
Update Owl2Anything version to 1.2.0

### DIFF
--- a/.github/workflows/owl2anything.yml
+++ b/.github/workflows/owl2anything.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  OWL2ANYTHING_VERSION: 1.1.0
+  OWL2ANYTHING_VERSION: 1.2.0
 
 jobs:
   owl2anything:


### PR DESCRIPTION
This will create a .py file for use in the new PyCram

This change has to be done on the main branch for the file to be available on the knowledge site.